### PR TITLE
dblp bibtex fetcher

### DIFF
--- a/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/brdf_models_for_accurate_and_efficient_rendering_of_glossy_surfaces.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/brdf_models_for_accurate_and_efficient_rendering_of_glossy_surfaces.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/LowKYU12,
+  author    = {Joakim L{\"o}w and
+               Joel Kronander and
+               Anders Ynnerman and
+               Jonas Unger},
+  title     = {BRDF models for accurate and efficient rendering of glossy
+               surfaces},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {1},
+  year      = {2012},
+  pages     = {9},
+  ee        = {http://doi.acm.org/10.1145/2077341.2077350},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/feature-adaptive_gpu_rendering_of_catmull-clark_subdivision_surfaces.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/feature-adaptive_gpu_rendering_of_catmull-clark_subdivision_surfaces.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/NiessnerLMD12,
+  author    = {Matthias Nie{\ss}ner and
+               Charles T. Loop and
+               Mark Meyer and
+               Tony DeRose},
+  title     = {Feature-adaptive GPU rendering of Catmull-Clark subdivision
+               surfaces},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {1},
+  year      = {2012},
+  pages     = {6},
+  ee        = {http://doi.acm.org/10.1145/2077341.2077347},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/fluid_simulation_using_laplacian_eigenfunctions.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/fluid_simulation_using_laplacian_eigenfunctions.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/WittLF12,
+  author    = {Tyler de Witt and
+               Christian Lessig and
+               Eugene Fiume},
+  title     = {Fluid simulation using Laplacian eigenfunctions},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {1},
+  year      = {2012},
+  pages     = {10},
+  ee        = {http://doi.acm.org/10.1145/2077341.2077351},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/interactive_sound_propagation_using_compact_acoustic_transfer_operators.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/interactive_sound_propagation_using_compact_acoustic_transfer_operators.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/AntaniCSM12,
+  author    = {Lakulish Antani and
+               Anish Chandak and
+               Lauri Savioja and
+               Dinesh Manocha},
+  title     = {Interactive sound propagation using compact acoustic transfer
+               operators},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {1},
+  year      = {2012},
+  pages     = {7},
+  ee        = {http://doi.acm.org/10.1145/2077341.2077348},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/learning_hatching_for_pen-and-ink_illustration_of_surfaces.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/learning_hatching_for_pen-and-ink_illustration_of_surfaces.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/KalogerakisNBH12,
+  author    = {Evangelos Kalogerakis and
+               Derek Nowrouzezahrai and
+               Simon Breslav and
+               Aaron Hertzmann},
+  title     = {Learning hatching for pen-and-ink illustration of surfaces},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {1},
+  year      = {2012},
+  pages     = {1},
+  ee        = {http://doi.acm.org/10.1145/2077341.2077342},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/physically-based_simulation_of_rainbows.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/physically-based_simulation_of_rainbows.bib
@@ -1,0 +1,17 @@
+@article{DBLP:journals/tog/SadeghiMLJSGJ12,
+  author    = {Iman Sadeghi and
+               Adolfo Mu{\~n}oz and
+               Philip Laven and
+               Wojciech Jarosz and
+               Francisco J. Ser{\'o}n and
+               Diego Gutierrez and
+               Henrik Wann Jensen},
+  title     = {Physically-based simulation of rainbows},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {1},
+  year      = {2012},
+  pages     = {3},
+  ee        = {http://doi.acm.org/10.1145/2077341.2077344},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/polydepth_real-time_penetration_depth_computation_using_iterative_contact-space_projection.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/polydepth_real-time_penetration_depth_computation_using_iterative_contact-space_projection.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/JeTLLK12,
+  author    = {Changsoo Je and
+               Min Tang and
+               Youngeun Lee and
+               Minkyoung Lee and
+               Young J. Kim},
+  title     = {PolyDepth: Real-time penetration depth computation using
+               iterative contact-space projection},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {1},
+  year      = {2012},
+  pages     = {5},
+  ee        = {http://doi.acm.org/10.1145/2077341.2077346},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/specular_reflection_from_woven_cloth.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/specular_reflection_from_woven_cloth.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/IrawanM12,
+  author    = {Piti Irawan and
+               Stephen R. Marschner},
+  title     = {Specular reflection from woven cloth},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {1},
+  year      = {2012},
+  pages     = {11},
+  ee        = {http://doi.acm.org/10.1145/2077341.2077352},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/temporally_coherent_completion_of_dynamic_shapes.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/temporally_coherent_completion_of_dynamic_shapes.bib
@@ -1,0 +1,17 @@
+@article{DBLP:journals/tog/LiLVPPPR12,
+  author    = {Hao Li and
+               Linjie Luo and
+               Daniel Vlasic and
+               Pieter Peers and
+               Jovan Popovic and
+               Mark Pauly and
+               Szymon Rusinkiewicz},
+  title     = {Temporally coherent completion of dynamic shapes},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {1},
+  year      = {2012},
+  pages     = {2},
+  ee        = {http://doi.acm.org/10.1145/2077341.2077343},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/three-dimensional_proxies_for_hand-drawn_characters.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_1_January_2012/three-dimensional_proxies_for_hand-drawn_characters.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/JainSMH12,
+  author    = {Eakta Jain and
+               Yaser Sheikh and
+               Moshe Mahler and
+               Jessica K. Hodgins},
+  title     = {Three-dimensional proxies for hand-drawn characters},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {1},
+  year      = {2012},
+  pages     = {8},
+  ee        = {http://doi.acm.org/10.1145/2077341.2077349},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_2_April_2012/animation_cartography_-_intrinsic_reconstruction_of_shape_and_motion.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_2_April_2012/animation_cartography_-_intrinsic_reconstruction_of_shape_and_motion.bib
@@ -1,0 +1,18 @@
+@article{DBLP:journals/tog/TevsBWIBKS12,
+  author    = {Art Tevs and
+               Alexander Berner and
+               Michael Wand and
+               Ivo Ihrke and
+               Martin Bokeloh and
+               Jens Kerber and
+               Hans-Peter Seidel},
+  title     = {Animation cartography - intrinsic reconstruction of shape
+               and motion},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {2},
+  year      = {2012},
+  pages     = {12},
+  ee        = {http://doi.acm.org/10.1145/2159516.2159517},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_2_April_2012/bilinear_spatiotemporal_basis_models.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_2_April_2012/bilinear_spatiotemporal_basis_models.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/AkhterSKMS12,
+  author    = {Ijaz Akhter and
+               Tomas Simon and
+               Sohaib Khan and
+               Iain Matthews and
+               Yaser Sheikh},
+  title     = {Bilinear spatiotemporal basis models},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {2},
+  year      = {2012},
+  pages     = {17},
+  ee        = {http://doi.acm.org/10.1145/2159516.2159523},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_2_April_2012/fast_high-resolution_appearance_editing_using_superimposed_projections.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_2_April_2012/fast_high-resolution_appearance_editing_using_superimposed_projections.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/AliagaYLSM12,
+  author    = {Daniel G. Aliaga and
+               Yu Hong Yeung and
+               Alvin J. Law and
+               Behzad Sajadi and
+               Aditi Majumder},
+  title     = {Fast high-resolution appearance editing using superimposed
+               projections},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {2},
+  year      = {2012},
+  pages     = {13},
+  ee        = {http://doi.acm.org/10.1145/2159516.2159518},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_2_April_2012/multiflip_for_energetic_two-phase_fluid_simulation.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_2_April_2012/multiflip_for_energetic_two-phase_fluid_simulation.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/BoydB12,
+  author    = {Landon Boyd and
+               Robert Bridson},
+  title     = {MultiFLIP for energetic two-phase fluid simulation},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {2},
+  year      = {2012},
+  pages     = {16},
+  ee        = {http://doi.acm.org/10.1145/2159516.2159522},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_2_April_2012/resolution_enhancement_by_vibrating_displays.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_2_April_2012/resolution_enhancement_by_vibrating_displays.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/BerthouzozF12,
+  author    = {Floraine Berthouzoz and
+               Raanan Fattal},
+  title     = {Resolution enhancement by vibrating displays},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {2},
+  year      = {2012},
+  pages     = {15},
+  ee        = {http://doi.acm.org/10.1145/2159516.2159521},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_2_April_2012/spacetime_expression_cloning_for_blendshapes.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_2_April_2012/spacetime_expression_cloning_for_blendshapes.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/SeolLSCAN12,
+  author    = {Yeongho Seol and
+               J. P. Lewis and
+               Jaewoo Seo and
+               Byungkuk Choi and
+               Ken Anjyo and
+               Junyong Noh},
+  title     = {Spacetime expression cloning for blendshapes},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {2},
+  year      = {2012},
+  pages     = {14},
+  ee        = {http://doi.acm.org/10.1145/2159516.2159519},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_3_May_2012/k-clustered_tensor_approximation_a_sparse_multilinear_model_for_real-time_rendering.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_3_May_2012/k-clustered_tensor_approximation_a_sparse_multilinear_model_for_real-time_rendering.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/TsaiS12,
+  author    = {Yu-Ting Tsai and
+               Zen-Chung Shih},
+  title     = {K-clustered tensor approximation: A sparse multilinear model
+               for real-time rendering},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {3},
+  year      = {2012},
+  pages     = {19},
+  ee        = {http://doi.acm.org/10.1145/2167076.2167077},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_3_May_2012/on_filtering_the_noise_from_the_random_parameters_in_monte_carlo_rendering.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_3_May_2012/on_filtering_the_noise_from_the_random_parameters_in_monte_carlo_rendering.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/SenD12,
+  author    = {Pradeep Sen and
+               Soheil Darabi},
+  title     = {On filtering the noise from the random parameters in Monte
+               Carlo rendering},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {3},
+  year      = {2012},
+  pages     = {18},
+  ee        = {http://doi.acm.org/10.1145/2167076.2167083},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_3_May_2012/printing_reflectance_functions.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_3_May_2012/printing_reflectance_functions.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/MalzbenderSSCDD12,
+  author    = {Tom Malzbender and
+               Ramin Samadani and
+               Steven Scher and
+               Adam Crume and
+               Douglas Dunn and
+               James Davis},
+  title     = {Printing reflectance functions},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {3},
+  year      = {2012},
+  pages     = {20},
+  ee        = {http://doi.acm.org/10.1145/2167076.2167078},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_3_May_2012/sparse_zonal_harmonic_factorization_for_efficient_sh_rotation.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_3_May_2012/sparse_zonal_harmonic_factorization_for_efficient_sh_rotation.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/NowrouzezahraiSF12,
+  author    = {Derek Nowrouzezahrai and
+               Patricio D. Simari and
+               Eugene Fiume},
+  title     = {Sparse zonal harmonic factorization for efficient SH rotation},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {3},
+  year      = {2012},
+  pages     = {23},
+  ee        = {http://doi.acm.org/10.1145/2167076.2167081},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_3_May_2012/symmetry-guided_texture_synthesis_and_manipulation.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_3_May_2012/symmetry-guided_texture_synthesis_and_manipulation.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/KimLF12,
+  author    = {Vladimir G. Kim and
+               Yaron Lipman and
+               Thomas A. Funkhouser},
+  title     = {Symmetry-guided texture synthesis and manipulation},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {3},
+  year      = {2012},
+  pages     = {22},
+  ee        = {http://doi.acm.org/10.1145/2167076.2167080},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_3_May_2012/topology-adaptive_interface_tracking_using_the_deformable_simplicial_complex.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_3_May_2012/topology-adaptive_interface_tracking_using_the_deformable_simplicial_complex.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/MisztalB12,
+  author    = {Marek Krzysztof Misztal and
+               Jakob Andreas B{\ae}rentzen},
+  title     = {Topology-adaptive interface tracking using the deformable
+               simplicial complex},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {3},
+  year      = {2012},
+  pages     = {24},
+  ee        = {http://doi.acm.org/10.1145/2167076.2167082},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_3_May_2012/variational_mesh_decomposition.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_3_May_2012/variational_mesh_decomposition.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/ZhangZWC12,
+  author    = {Juyong Zhang and
+               Jianmin Zheng and
+               Chunlin Wu and
+               Jianfei Cai},
+  title     = {Variational mesh decomposition},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {3},
+  year      = {2012},
+  pages     = {21},
+  ee        = {http://doi.acm.org/10.1145/2167076.2167079},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/3d_imaging_spectroscopy_for_measuring_hyperspectral_patterns_on_solid_objects.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/3d_imaging_spectroscopy_for_measuring_hyperspectral_patterns_on_solid_objects.bib
@@ -1,0 +1,18 @@
+@article{DBLP:journals/tog/KimRDHPKB12,
+  author    = {Min H. Kim and
+               Holly E. Rushmeier and
+               Julie Dorsey and
+               Todd Alan Harvey and
+               Richard O. Prum and
+               David S. Kittle and
+               David J. Brady},
+  title     = {3D imaging spectroscopy for measuring hyperspectral patterns
+               on solid objects},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {38},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185534},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/a_probabilistic_model_for_component-based_shape_synthesis.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/a_probabilistic_model_for_component-based_shape_synthesis.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/KalogerakisCKK12,
+  author    = {Evangelos Kalogerakis and
+               Siddhartha Chaudhuri and
+               Daphne Koller and
+               Vladlen Koltun},
+  title     = {A probabilistic model for component-based shape synthesis},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {55},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185551},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/adaptive_image-based_intersection_volume.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/adaptive_image-based_intersection_volume.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/WangFP12,
+  author    = {Bin Wang and
+               Fran\c{c}ois Faure and
+               Dinesh K. Pai},
+  title     = {Adaptive image-based intersection volume},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {97},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185593},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/adaptive_manifolds_for_real-time_high-dimensional_filtering.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/adaptive_manifolds_for_real-time_high-dimensional_filtering.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/GastalO12,
+  author    = {Eduardo S. L. Gastal and
+               Manuel M. Oliveira},
+  title     = {Adaptive manifolds for real-time high-dimensional filtering},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {33},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185529},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/an_algebraic_model_for_parameterized_shape_editing.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/an_algebraic_model_for_parameterized_shape_editing.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/BokelohWSK12,
+  author    = {Martin Bokeloh and
+               Michael Wand and
+               Hans-Peter Seidel and
+               Vladlen Koltun},
+  title     = {An algebraic model for parameterized shape editing},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {78},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185574},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/an_analytic_model_for_full_spectral_sky-dome_radiance.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/an_analytic_model_for_full_spectral_sky-dome_radiance.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/HosekW12,
+  author    = {Lukas Hosek and
+               Alexander Wilkie},
+  title     = {An analytic model for full spectral sky-dome radiance},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {95},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185591},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/animating_bubble_interactions_in_a_liquid_foam.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/animating_bubble_interactions_in_a_liquid_foam.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/BusaryevDWR12,
+  author    = {Oleksiy Busaryev and
+               Tamal K. Dey and
+               Huamin Wang and
+               Zhong Ren},
+  title     = {Animating bubble interactions in a liquid foam},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {63},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185559},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/beady_interactive_beadwork_design_and_construction.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/beady_interactive_beadwork_design_and_construction.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/IgarashiIM12,
+  author    = {Yuki Igarashi and
+               Takeo Igarashi and
+               Jun Mitani},
+  title     = {Beady: interactive beadwork design and construction},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {49},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185545},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/bidirectional_lightcuts.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/bidirectional_lightcuts.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/WalterKB12,
+  author    = {Bruce Walter and
+               Pramook Khungurn and
+               Kavita Bala},
+  title     = {Bidirectional lightcuts},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {59},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185555},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/binocular_tone_mapping.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/binocular_tone_mapping.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/YangZWH12,
+  author    = {Xuan S. Yang and
+               Linling Zhang and
+               Tien-Tsin Wong and
+               Pheng-Ann Heng},
+  title     = {Binocular tone mapping},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {93},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185589},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/bounded_distortion_mapping_spaces_for_triangular_meshes.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/bounded_distortion_mapping_spaces_for_triangular_meshes.bib
@@ -1,0 +1,11 @@
+@article{DBLP:journals/tog/Lipman12,
+  author    = {Yaron Lipman},
+  title     = {Bounded distortion mapping spaces for triangular meshes},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {108},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185604},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/continuous_character_control_with_low-dimensional_embeddings.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/continuous_character_control_with_low-dimensional_embeddings.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/LevineWHPK12,
+  author    = {Sergey Levine and
+               Jack M. Wang and
+               Alexis Haraux and
+               Zoran Popovic and
+               Vladlen Koltun},
+  title     = {Continuous character control with low-dimensional embeddings},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {28},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185524},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/continuous_penalty_forces.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/continuous_penalty_forces.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/TangMOT12,
+  author    = {Min Tang and
+               Dinesh Manocha and
+               Miguel A. Otaduy and
+               Ruofeng Tong},
+  title     = {Continuous penalty forces},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {107},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185603},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/coupled_3d_reconstruction_of_sparse_facial_hair_and_skin.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/coupled_3d_reconstruction_of_sparse_facial_hair_and_skin.bib
@@ -1,0 +1,17 @@
+@article{DBLP:journals/tog/BeelerBNBMSG12,
+  author    = {Thabo Beeler and
+               Bernd Bickel and
+               Gioacchino Noris and
+               Paul A. Beardsley and
+               Steve Marschner and
+               Robert W. Sumner and
+               Markus H. Gross},
+  title     = {Coupled 3D reconstruction of sparse facial hair and skin},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {117},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185613},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/crossshade_shading_concept_sketches_using_cross-section_curves.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/crossshade_shading_concept_sketches_using_cross-section_curves.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/ShaoBSS12,
+  author    = {Cloud Shao and
+               Adrien Bousseau and
+               Alla Sheffer and
+               Karan Singh},
+  title     = {CrossShade: shading concept sketches using cross-section
+               curves},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {45},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185541},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/decoupling_algorithms_from_schedules_for_easy_optimization_of_image_processing_pipelines.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/decoupling_algorithms_from_schedules_for_easy_optimization_of_image_processing_pipelines.bib
@@ -1,0 +1,17 @@
+@article{DBLP:journals/tog/Ragan-KelleyAPLAD12,
+  author    = {Jonathan Ragan-Kelley and
+               Andrew Adams and
+               Sylvain Paris and
+               Marc Levoy and
+               Saman P. Amarasinghe and
+               Fr{\'e}do Durand},
+  title     = {Decoupling algorithms from schedules for easy optimization
+               of image processing pipelines},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {32},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185528},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/deformable_objects_alive.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/deformable_objects_alive.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/CorosMTSSG12,
+  author    = {Stelian Coros and
+               Sebastian Martin and
+               Bernhard Thomaszewski and
+               Christian Schumacher and
+               Robert W. Sumner and
+               Markus H. Gross},
+  title     = {Deformable objects alive!},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {69},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185565},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/design_of_self-supporting_surfaces.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/design_of_self-supporting_surfaces.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/VougaHWP12,
+  author    = {Etienne Vouga and
+               Mathias H{\"o}binger and
+               Johannes Wallner and
+               Helmut Pottmann},
+  title     = {Design of self-supporting surfaces},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {87},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185583},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/design_preserving_garment_transfer.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/design_preserving_garment_transfer.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/BrouetSBC12,
+  author    = {Remi Brouet and
+               Alla Sheffer and
+               Laurence Boissieux and
+               Marie-Paule Cani},
+  title     = {Design preserving garment transfer},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {36},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185532},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/diffusion_curve_textures_for_resolution_independent_texture_mapping.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/diffusion_curve_textures_for_resolution_independent_texture_mapping.bib
@@ -1,0 +1,19 @@
+@article{DBLP:journals/tog/SunXDLXWTG12,
+  author    = {Xin Sun and
+               Guofu Xie and
+               Yue Dong and
+               Stephen Lin and
+               Weiwei Xu and
+               Wencheng Wang and
+               Xin Tong and
+               Baining Guo},
+  title     = {Diffusion curve textures for resolution independent texture
+               mapping},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {74},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185570},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/discovery_of_complex_behaviors_through_contact-invariant_optimization.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/discovery_of_complex_behaviors_through_contact-invariant_optimization.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/MordatchTP12,
+  author    = {Igor Mordatch and
+               Emanuel Todorov and
+               Zoran Popovic},
+  title     = {Discovery of complex behaviors through contact-invariant
+               optimization},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {43},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185539},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/discrete_bi-laplacians_and_biharmonic_b-splines.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/discrete_bi-laplacians_and_biharmonic_b-splines.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/FengW12,
+  author    = {Powei Feng and
+               Joe D. Warren},
+  title     = {Discrete bi-Laplacians and biharmonic b-splines},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {115},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185611},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/discrete_viscous_sheets.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/discrete_viscous_sheets.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/BattyUAG12,
+  author    = {Christopher Batty and
+               Andres Uribe and
+               Basile Audoly and
+               Eitan Grinspun},
+  title     = {Discrete viscous sheets},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {113},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185609},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/drape_dressing_any_person.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/drape_dressing_any_person.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/GuanRHWB12,
+  author    = {Peng Guan and
+               Loretta Reiss and
+               David A. Hirshberg and
+               Alexander Weiss and
+               Michael J. Black},
+  title     = {DRAPE: DRessing Any PErson},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {35},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185531},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/dual_loops_meshing_quality_quad_layouts_on_manifolds.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/dual_loops_meshing_quality_quad_layouts_on_manifolds.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/CampenBK12,
+  author    = {Marcel Campen and
+               David Bommes and
+               Leif Kobbelt},
+  title     = {Dual loops meshing: quality quad layouts on manifolds},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {110},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185606},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/edge-guided_resolution_enhancement_in_projectors_via_optical_pixel_sharing.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/edge-guided_resolution_enhancement_in_projectors_via_optical_pixel_sharing.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/SajadiGM12,
+  author    = {Behzad Sajadi and
+               M. Gopi and
+               Aditi Majumder},
+  title     = {Edge-guided resolution enhancement in projectors via optical
+               pixel sharing},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {79},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185575},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/efficient_geometrically_exact_continuous_collision_detection.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/efficient_geometrically_exact_continuous_collision_detection.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/BrochuEB12,
+  author    = {Tyson Brochu and
+               Essex Edwards and
+               Robert Bridson},
+  title     = {Efficient geometrically exact continuous collision detection},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {96},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185592},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/energy-based_self-collision_culling_for_arbitrary_mesh_deformations.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/energy-based_self-collision_culling_for_arbitrary_mesh_deformations.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/ZhengJ12,
+  author    = {Changxi Zheng and
+               Doug L. James},
+  title     = {Energy-based self-collision culling for arbitrary mesh deformations},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {98},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185594},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/eulerian_video_magnification_for_revealing_subtle_changes_in_the_world.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/eulerian_video_magnification_for_revealing_subtle_changes_in_the_world.bib
@@ -1,0 +1,17 @@
+@article{DBLP:journals/tog/WuRSGDF12,
+  author    = {Hao-Yu Wu and
+               Michael Rubinstein and
+               Eugene Shih and
+               John V. Guttag and
+               Fr{\'e}do Durand and
+               William T. Freeman},
+  title     = {Eulerian video magnification for revealing subtle changes
+               in the world},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {65},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185561},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/exploring_collections_of_3d_models_using_fuzzy_correspondences.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/exploring_collections_of_3d_models_using_fuzzy_correspondences.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/KimLMDF12,
+  author    = {Vladimir G. Kim and
+               Wilmot Li and
+               Niloy J. Mitra and
+               Stephen DiVerdi and
+               Thomas A. Funkhouser},
+  title     = {Exploring collections of 3D models using fuzzy correspondences},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {54},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185550},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/eyecatch_simulating_visuomotor_coordination_for_object_interception.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/eyecatch_simulating_visuomotor_coordination_for_object_interception.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/YeoLNP12,
+  author    = {Sang Hoon Yeo and
+               Martin Lesmana and
+               Debanga Raj Neog and
+               Dinesh K. Pai},
+  title     = {Eyecatch: simulating visuomotor coordination for object
+               interception},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {42},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185538},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/fabricating_articulated_characters_from_skinned_meshes.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/fabricating_articulated_characters_from_skinned_meshes.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/BacherBJP12,
+  author    = {Moritz B{\"a}cher and
+               Bernd Bickel and
+               Doug L. James and
+               Hanspeter Pfister},
+  title     = {Fabricating articulated characters from skinned meshes},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {47},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185543},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/fast_automatic_skinning_transformations.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/fast_automatic_skinning_transformations.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/JacobsonBKPS12,
+  author    = {Alec Jacobson and
+               Ilya Baran and
+               Ladislav Kavan and
+               Jovan Popovic and
+               Olga Sorkine},
+  title     = {Fast automatic skinning transformations},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {77},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185573},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/fields_on_symmetric_surfaces.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/fields_on_symmetric_surfaces.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/PanozzoLPZ12,
+  author    = {Daniele Panozzo and
+               Yaron Lipman and
+               Enrico Puppo and
+               Denis Zorin},
+  title     = {Fields on symmetric surfaces},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {111},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185607},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/fit_and_diverse_set_evolution_for_inspiring_3d_shape_galleries.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/fit_and_diverse_set_evolution_for_inspiring_3d_shape_galleries.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/XuZCC12,
+  author    = {Kai Xu and
+               Hao Zhang and
+               Daniel Cohen-Or and
+               Baoquan Chen},
+  title     = {Fit and diverse: set evolution for inspiring 3D shape galleries},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {57},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185553},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/functional_maps_a_flexible_representation_of_maps_between_shapes.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/functional_maps_a_flexible_representation_of_maps_between_shapes.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/OvsjanikovBSBG12,
+  author    = {Maks Ovsjanikov and
+               Mirela Ben-Chen and
+               Justin Solomon and
+               Adrian Butscher and
+               Leonidas J. Guibas},
+  title     = {Functional maps: a flexible representation of maps between
+               shapes},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {30},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185526},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/gabor_noise_by_example.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/gabor_noise_by_example.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/GalerneLLD12,
+  author    = {Bruno Galerne and
+               Ares Lagae and
+               Sylvain Lefebvre and
+               George Drettakis},
+  title     = {Gabor noise by example},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {73},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185569},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/ghost_sph_for_animating_water.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/ghost_sph_for_animating_water.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/SchechterB12,
+  author    = {Hagit Schechter and
+               Robert Bridson},
+  title     = {Ghost SPH for animating water},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {61},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185557},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/global_parametrization_by_incremental_flattening.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/global_parametrization_by_incremental_flattening.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/MylesZ12,
+  author    = {Ashish Myles and
+               Denis Zorin},
+  title     = {Global parametrization by incremental flattening},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {109},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185605},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/guided_exploration_of_physically_valid_shapes_for_furniture_design.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/guided_exploration_of_physically_valid_shapes_for_furniture_design.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/UmetaniIM12,
+  author    = {Nobuyuki Umetani and
+               Takeo Igarashi and
+               Niloy J. Mitra},
+  title     = {Guided exploration of physically valid shapes for furniture
+               design},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {86},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185582},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/helpinghand_example-based_stroke_stylization.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/helpinghand_example-based_stroke_stylization.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/LuYFD12,
+  author    = {Jingwan Lu and
+               Fisher Yu and
+               Adam Finkelstein and
+               Stephen DiVerdi},
+  title     = {HelpingHand: example-based stroke stylization},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {46},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185542},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/highlight_microdisparity_for_improved_gloss_depiction.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/highlight_microdisparity_for_improved_gloss_depiction.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/TemplinDRMS12,
+  author    = {Krzysztof Templin and
+               Piotr Didyk and
+               Tobias Ritschel and
+               Karol Myszkowski and
+               Hans-Peter Seidel},
+  title     = {Highlight microdisparity for improved gloss depiction},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {92},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185588},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/how_do_humans_sketch_objects.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/how_do_humans_sketch_objects.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/EitzHA12,
+  author    = {Mathias Eitz and
+               James Hays and
+               Marc Alexa},
+  title     = {How do humans sketch objects?},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {44},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185540},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/image-based_rendering_for_scenes_with_reflections.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/image-based_rendering_for_scenes_with_reflections.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/SinhaKGSS12,
+  author    = {Sudipta N. Sinha and
+               Johannes Kopf and
+               Michael Goesele and
+               Daniel Scharstein and
+               Richard Szeliski},
+  title     = {Image-based rendering for scenes with reflections},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {100},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185596},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/image_melding_combining_inconsistent_images_using_patch-based_synthesis.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/image_melding_combining_inconsistent_images_using_patch-based_synthesis.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/DarabiSBGS12,
+  author    = {Soheil Darabi and
+               Eli Shechtman and
+               Connelly Barnes and
+               Dan B. Goldman and
+               Pradeep Sen},
+  title     = {Image melding: combining inconsistent images using patch-based
+               synthesis},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {82},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185578},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/interactive_editing_of_deformable_simulations.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/interactive_editing_of_deformable_simulations.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/BarbicSG12,
+  author    = {Jernej Barbic and
+               Funshing Sin and
+               Eitan Grinspun},
+  title     = {Interactive editing of deformable simulations},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {70},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185566},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/interactive_images_cuboid_proxies_for_smart_image_manipulation.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/interactive_images_cuboid_proxies_for_smart_image_manipulation.bib
@@ -1,0 +1,17 @@
+@article{DBLP:journals/tog/ZhengCCZHM12,
+  author    = {Youyi Zheng and
+               Xiang Chen and
+               Ming-Ming Cheng and
+               Kun Zhou and
+               Shi-Min Hu and
+               Niloy J. Mitra},
+  title     = {{\it Interactive images}: cuboid proxies for smart image
+               manipulation},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {99},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185595},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/interactive_spacetime_control_of_deformable_objects.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/interactive_spacetime_control_of_deformable_objects.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/HildebrandtSTP12,
+  author    = {Klaus Hildebrandt and
+               Christian Schulz and
+               Christoph von Tycowicz and
+               Konrad Polthier},
+  title     = {Interactive spacetime control of deformable objects},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {71},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185567},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/keynote_jane_mcgonigal.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/keynote_jane_mcgonigal.bib
@@ -1,0 +1,10 @@
+@article{DBLP:journals/tog/McGonigal12,
+  author    = {Jane McGonigal},
+  title     = {Keynote: Jane McGonigal},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  ee        = {http://doi.acm.org/10.1145/2185520.2349378},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/lagrangian_vortex_sheets_for_animating_fluids.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/lagrangian_vortex_sheets_for_animating_fluids.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/PfaffTG12,
+  author    = {Tobias Pfaff and
+               Nils Th{\"u}rey and
+               Markus H. Gross},
+  title     = {Lagrangian vortex sheets for animating fluids},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {112},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185608},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/manifold_exploration_a_markov_chain_monte_carlo_technique_for_rendering_scenes_with_difficult_specular_transport.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/manifold_exploration_a_markov_chain_monte_carlo_technique_for_rendering_scenes_with_difficult_specular_transport.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/JakobM12,
+  author    = {Wenzel Jakob and
+               Steve Marschner},
+  title     = {Manifold exploration: a Markov Chain Monte Carlo technique
+               for rendering scenes with difficult specular transport},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {58},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185554},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/mass_splitting_for_jitter-free_parallel_rigid_body_simulation.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/mass_splitting_for_jitter-free_parallel_rigid_body_simulation.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/TongeBV12,
+  author    = {Richard Tonge and
+               Feodor Benevolenski and
+               Andrey Voroshilov},
+  title     = {Mass splitting for jitter-free parallel rigid body simulation},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {105},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185601},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/motion-driven_concatenative_synthesis_of_cloth_sounds.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/motion-driven_concatenative_synthesis_of_cloth_sounds.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/AnJM12,
+  author    = {Steven S. An and
+               Doug L. James and
+               Steve Marschner},
+  title     = {Motion-driven concatenative synthesis of cloth sounds},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {102},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185598},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/object-space_multiphase_implicit_functions.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/object-space_multiphase_implicit_functions.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/YuanYW12,
+  author    = {Zhan Yuan and
+               Yizhou Yu and
+               Wenping Wang},
+  title     = {Object-space multiphase implicit functions},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {114},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185610},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/optimizing_locomotion_controllers_using_biologically-based_actuators_and_objectives.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/optimizing_locomotion_controllers_using_biologically-based_actuators_and_objectives.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/WangHDK12,
+  author    = {Jack M. Wang and
+               Samuel R. Hamner and
+               Scott L. Delp and
+               Vladlen Koltun},
+  title     = {Optimizing locomotion controllers using biologically-based
+               actuators and objectives},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {25},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185521},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/panorama_weaving_fast_and_flexible_seam_processing.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/panorama_weaving_fast_and_flexible_seam_processing.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/SummaTP12,
+  author    = {Brian Summa and
+               Julien Tierny and
+               Valerio Pascucci},
+  title     = {Panorama weaving: fast and flexible seam processing},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {83},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185579},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/physical_face_cloning.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/physical_face_cloning.bib
@@ -1,0 +1,20 @@
+@article{DBLP:journals/tog/BickelKSTBBJMMG12,
+  author    = {Bernd Bickel and
+               Peter Kaufmann and
+               M{\'e}lina Skouras and
+               Bernhard Thomaszewski and
+               Derek Bradley and
+               Thabo Beeler and
+               Philip Jackson and
+               Steve Marschner and
+               Wojciech Matusik and
+               Markus H. Gross},
+  title     = {Physical face cloning},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {118},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185614},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/plastic_trees_interactive_self-adapting_botanical_tree_models.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/plastic_trees_interactive_self-adapting_botanical_tree_models.bib
@@ -1,0 +1,19 @@
+@article{DBLP:journals/tog/PirkSKSNMBD12,
+  author    = {S{\"o}ren Pirk and
+               Ondrej Stava and
+               Julian Kratt and
+               Michel Abdul-Massih Said and
+               Boris Neubert and
+               Radom\'{\i}r Mech and
+               Bedrich Benes and
+               Oliver Deussen},
+  title     = {Plastic trees: interactive self-adapting botanical tree
+               models},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {50},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185546},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/point_sampling_with_general_noise_spectrum.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/point_sampling_with_general_noise_spectrum.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/ZhouHWW12,
+  author    = {Yahan Zhou and
+               Haibin Huang and
+               Li-Yi Wei and
+               Rui Wang},
+  title     = {Point sampling with general noise spectrum},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {76},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185572},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/position-correcting_tools_for_2d_digital_fabrication.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/position-correcting_tools_for_2d_digital_fabrication.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/RiversMD12,
+  author    = {Alec R. Rivers and
+               Ilan E. Moyer and
+               Fr{\'e}do Durand},
+  title     = {Position-correcting tools for 2D digital fabrication},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {88},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185584},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/practical_temporal_consistency_for_image-based_graphics_applications.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/practical_temporal_consistency_for_image-based_graphics_applications.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/LangWASG12,
+  author    = {Manuel Lang and
+               Oliver Wang and
+               Tunc Aydin and
+               Aljoscha Smolic and
+               Markus H. Gross},
+  title     = {Practical temporal consistency for image-based graphics
+               applications},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {34},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185530},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/precomputed_acceleration_noise_for_improved_rigid-body_sound.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/precomputed_acceleration_noise_for_improved_rigid-body_sound.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/ChadwickZJ12,
+  author    = {Jeffrey N. Chadwick and
+               Changxi Zheng and
+               Doug L. James},
+  title     = {Precomputed acceleration noise for improved rigid-body sound},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {103},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185599},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/primal-dual_coding_to_probe_light_transport.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/primal-dual_coding_to_probe_light_transport.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/OTooleRK12,
+  author    = {Matthew O'Toole and
+               Ramesh Raskar and
+               Kiriakos N. Kutulakos},
+  title     = {Primal-dual coding to probe light transport},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {39},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185535},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/printing_spatially-varying_reflectance_for_reproducing_hdr_images.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/printing_spatially-varying_reflectance_for_reproducing_hdr_images.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/DongTPG12,
+  author    = {Yue Dong and
+               Xin Tong and
+               Fabio Pellacini and
+               Baining Guo},
+  title     = {Printing spatially-varying reflectance for reproducing HDR
+               images},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {40},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185536},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/push_it_real_perceiving_causality_in_virtual_interactions.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/push_it_real_perceiving_causality_in_virtual_interactions.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/HoyetMO12,
+  author    = {Ludovic Hoyet and
+               Rachel McDonnell and
+               Carol O'Sullivan},
+  title     = {Push it real: perceiving causality in virtual interactions},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {90},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185586},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/reconstructing_the_indirect_light_field_for_global_illumination.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/reconstructing_the_indirect_light_field_for_global_illumination.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/LehtinenALD12,
+  author    = {Jaakko Lehtinen and
+               Timo Aila and
+               Samuli Laine and
+               Fr{\'e}do Durand},
+  title     = {Reconstructing the indirect light field for global illumination},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {51},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185547},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/reflections_on_simultaneous_impact.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/reflections_on_simultaneous_impact.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/SmithKVTG12,
+  author    = {Breannan Smith and
+               Danny M. Kaufman and
+               Etienne Vouga and
+               Rasmus Tamstorf and
+               Eitan Grinspun},
+  title     = {Reflections on simultaneous impact},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {106},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185602},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/render_me_real_investigating_the_effect_of_render_style_on_the_perception_of_animated_virtual_humans.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/render_me_real_investigating_the_effect_of_render_style_on_the_perception_of_animated_virtual_humans.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/McDonnellBB12,
+  author    = {Rachel McDonnell and
+               Martin Breidt and
+               Heinrich H. B{\"u}lthoff},
+  title     = {Render me real?: investigating the effect of render style
+               on the perception of animated virtual humans},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {91},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185587},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/revel_tactile_feedback_technology_for_augmented_reality.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/revel_tactile_feedback_technology_for_augmented_reality.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/BauP12,
+  author    = {Olivier Bau and
+               Ivan Poupyrev},
+  title     = {REVEL: tactile feedback technology for augmented reality},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {89},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185585},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/rig-space_physics.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/rig-space_physics.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/HahnMTSCG12,
+  author    = {Fabian Hahn and
+               Sebastian Martin and
+               Bernhard Thomaszewski and
+               Robert W. Sumner and
+               Stelian Coros and
+               Markus H. Gross},
+  title     = {Rig-space physics},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {72},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185568},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/robust_modeling_of_constant_mean_curvature_surfaces.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/robust_modeling_of_constant_mean_curvature_surfaces.bib
@@ -1,0 +1,18 @@
+@article{DBLP:journals/tog/PanCLHDPZW12,
+  author    = {Hao Pan and
+               Yi-King Choi and
+               Yang Liu and
+               Wenchao Hu and
+               Qiang Du and
+               Konrad Polthier and
+               Caiming Zhang and
+               Wenping Wang},
+  title     = {Robust modeling of constant mean curvature surfaces},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {85},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185581},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/schelling_points_on_3d_surface_meshes.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/schelling_points_on_3d_surface_meshes.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/ChenSPF12,
+  author    = {Xiaobai Chen and
+               Abulhair Saparov and
+               Bill Pang and
+               Thomas A. Funkhouser},
+  title     = {Schelling points on 3D surface meshes},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {29},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185525},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/selectively_de-animating_video.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/selectively_de-animating_video.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/BaiAAR12,
+  author    = {Jiamin Bai and
+               Aseem Agarwala and
+               Maneesh Agrawala and
+               Ravi Ramamoorthi},
+  title     = {Selectively de-animating video},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {66},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185562},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/single-view_hair_modeling_for_portrait_manipulation.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/single-view_hair_modeling_for_portrait_manipulation.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/ChaiWWYGZ12,
+  author    = {Menglei Chai and
+               Lvdi Wang and
+               Yanlin Weng and
+               Yizhou Yu and
+               Baining Guo and
+               Kun Zhou},
+  title     = {Single-view hair modeling for portrait manipulation},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {116},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185612},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/sketch-based_shape_retrieval.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/sketch-based_shape_retrieval.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/EitzRBHA12,
+  author    = {Mathias Eitz and
+               Ronald Richter and
+               Tamy Boubekeur and
+               Kristian Hildebrand and
+               Marc Alexa},
+  title     = {Sketch-based shape retrieval},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {31},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185527},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/soft_body_locomotion.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/soft_body_locomotion.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/TanTL12,
+  author    = {Jie Tan and
+               Greg Turk and
+               C. Karen Liu},
+  title     = {Soft body locomotion},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {26},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185522},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/stitch_meshes_for_modeling_knitted_clothing_with_yarn-level_detail.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/stitch_meshes_for_modeling_knitted_clothing_with_yarn-level_detail.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/YukselKJM12,
+  author    = {Cem Yuksel and
+               Jonathan M. Kaldor and
+               Doug L. James and
+               Steve Marschner},
+  title     = {Stitch meshes for modeling knitted clothing with yarn-level
+               detail},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {37},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185533},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/stochastic_tomography_and_its_applications_in_3d_imaging_of_mixing_fluids.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/stochastic_tomography_and_its_applications_in_3d_imaging_of_mixing_fluids.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/GregsonKHH12,
+  author    = {James Gregson and
+               Michael Krimerman and
+               Matthias B. Hullin and
+               Wolfgang Heidrich},
+  title     = {Stochastic tomography and its applications in 3D imaging
+               of mixing fluids},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {52},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185548},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/stress_relief_improving_structural_strength_of_3d_printable_objects.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/stress_relief_improving_structural_strength_of_3d_printable_objects.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/StavaVBCM12,
+  author    = {Ondrej Stava and
+               Juraj Vanek and
+               Bedrich Benes and
+               Nathan A. Carr and
+               Radom\'{\i}r Mech},
+  title     = {Stress relief: improving structural strength of 3D printable
+               objects},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {48},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185544},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/structure-aware_synthesis_for_predictive_woven_fabric_appearance.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/structure-aware_synthesis_for_predictive_woven_fabric_appearance.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/ZhaoJMB12,
+  author    = {Shuang Zhao and
+               Wenzel Jakob and
+               Steve Marschner and
+               Kavita Bala},
+  title     = {Structure-aware synthesis for predictive woven fabric appearance},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {75},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185571},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/surface_flows_for_image-based_shading_design.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/surface_flows_for_image-based_shading_design.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/VergneBFG12,
+  author    = {Romain Vergne and
+               Pascal Barla and
+               Roland W. Fleming and
+               Xavier Granier},
+  title     = {Surface flows for image-based shading design},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {94},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185590},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/synthesis_of_detailed_hand_manipulations_using_contact_sampling.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/synthesis_of_detailed_hand_manipulations_using_contact_sampling.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/YeL12,
+  author    = {Yuting Ye and
+               C. Karen Liu},
+  title     = {Synthesis of detailed hand manipulations using contact sampling},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {41},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185537},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/synthesizing_open_worlds_with_constraints_using_locally_annealed_reversible_jump_mcmc.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/synthesizing_open_worlds_with_constraints_using_locally_annealed_reversible_jump_mcmc.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/YehYWGH12,
+  author    = {Yi-Ting Yeh and
+               Lingfeng Yang and
+               Matthew Watson and
+               Noah D. Goodman and
+               Pat Hanrahan},
+  title     = {Synthesizing open worlds with constraints using locally
+               annealed reversible jump MCMC},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {56},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185552},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/tailored_displays_to_compensate_for_visual_aberrations.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/tailored_displays_to_compensate_for_visual_aberrations.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/PamplonaOAR12,
+  author    = {Vitor F. Pamplona and
+               Manuel M. Oliveira and
+               Daniel G. Aliaga and
+               Ramesh Raskar},
+  title     = {Tailored displays to compensate for visual aberrations},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {81},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185577},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/tensor_displays_compressive_light_field_synthesis_using_multilayer_displays_with_directional_backlighting.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/tensor_displays_compressive_light_field_synthesis_using_multilayer_displays_with_directional_backlighting.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/WetzsteinLHR12,
+  author    = {Gordon Wetzstein and
+               Douglas Lanman and
+               Matthew Hirsch and
+               Ramesh Raskar},
+  title     = {Tensor displays: compressive light field synthesis using
+               multilayer displays with directional backlighting},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {80},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185576},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/tools_for_placing_cuts_and_transitions_in_interview_video.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/tools_for_placing_cuts_and_transitions_in_interview_video.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/BerthouzozLA12,
+  author    = {Floraine Berthouzoz and
+               Wilmot Li and
+               Maneesh Agrawala},
+  title     = {Tools for placing cuts and transitions in interview video},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {67},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185563},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/tracking_surfaces_with_evolving_topology.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/tracking_surfaces_with_evolving_topology.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/Bojsen-HansenLW12,
+  author    = {Morten Bojsen-Hansen and
+               Hao Li and
+               Chris Wojtan},
+  title     = {Tracking surfaces with evolving topology},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {53},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185549},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/understanding_and_improving_the_realism_of_image_composites.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/understanding_and_improving_the_realism_of_image_composites.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/XueADR12,
+  author    = {Su Xue and
+               Aseem Agarwala and
+               Julie Dorsey and
+               Holly E. Rushmeier},
+  title     = {Understanding and improving the realism of image composites},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {84},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185580},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/underwater_rigid_body_dynamics.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/underwater_rigid_body_dynamics.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/WeissmannP12,
+  author    = {Steffen Wei{\ss}mann and
+               Ulrich Pinkall},
+  title     = {Underwater rigid body dynamics},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {104},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185600},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/versatile_rigid-fluid_coupling_for_incompressible_sph.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/versatile_rigid-fluid_coupling_for_incompressible_sph.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/AkinciIAST12,
+  author    = {Nadir Akinci and
+               Markus Ihmsen and
+               Gizem Akinci and
+               Barbara Solenthaler and
+               Matthias Teschner},
+  title     = {Versatile rigid-fluid coupling for incompressible SPH},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {62},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185558},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/video-based_3d_motion_capture_through_biped_control.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/video-based_3d_motion_capture_through_biped_control.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/VondrakSHJ12,
+  author    = {Marek Vondrak and
+               Leonid Sigal and
+               Jessica K. Hodgins and
+               Odest Chadwicke Jenkins},
+  title     = {Video-based 3D motion capture through biped control},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {27},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185523},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/video_deblurring_for_hand-held_cameras_using_patch-based_synthesis.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/video_deblurring_for_hand-held_cameras_using_patch-based_synthesis.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/ChoWL12,
+  author    = {Sunghyun Cho and
+               Jue Wang and
+               Seungyong Lee},
+  title     = {Video deblurring for hand-held cameras using patch-based
+               synthesis},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {64},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185560},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/videoscapes_exploring_sparse,_unstructured_video_collections.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/videoscapes_exploring_sparse,_unstructured_video_collections.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/TompkinKKT12,
+  author    = {James Tompkin and
+               Kwang In Kim and
+               Jan Kautz and
+               Christian Theobalt},
+  title     = {Videoscapes: exploring sparse, unstructured video collections},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {68},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185564},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/virtual_ray_lights_for_rendering_scenes_with_participating_media.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/virtual_ray_lights_for_rendering_scenes_with_participating_media.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/NovakNDJ12,
+  author    = {Jan Nov{\'a}k and
+               Derek Nowrouzezahrai and
+               Carsten Dachsbacher and
+               Wojciech Jarosz},
+  title     = {Virtual ray lights for rendering scenes with participating
+               media},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {60},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185556},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/what_makes_paris_look_like_paris.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_4_July_2012/what_makes_paris_look_like_paris.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/DoerschSGSE12,
+  author    = {Carl Doersch and
+               Saurabh Singh and
+               Abhinav Gupta and
+               Josef Sivic and
+               Alexei A. Efros},
+  title     = {What makes Paris look like Paris?},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {4},
+  year      = {2012},
+  pages     = {101},
+  ee        = {http://doi.acm.org/10.1145/2185520.2185597},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_5_August_2012/a_theory_of_monte_carlo_visibility_sampling.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_5_August_2012/a_theory_of_monte_carlo_visibility_sampling.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/RamamoorthiAMN12,
+  author    = {Ravi Ramamoorthi and
+               John Anderson and
+               Mark Meyer and
+               Derek Nowrouzezahrai},
+  title     = {A theory of monte carlo visibility sampling},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {5},
+  year      = {2012},
+  pages     = {121},
+  ee        = {http://doi.acm.org/10.1145/2231816.2231819},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_5_August_2012/high-quality_image_deblurring_with_panchromatic_pixels.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_5_August_2012/high-quality_image_deblurring_with_panchromatic_pixels.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/WangHBQM12,
+  author    = {Sen Wang and
+               Tingbo Hou and
+               John Border and
+               Hong Qin and
+               Rodney L. Miller},
+  title     = {High-quality image deblurring with panchromatic pixels},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {5},
+  year      = {2012},
+  pages     = {120},
+  ee        = {http://doi.acm.org/10.1145/2231816.2231818},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_5_August_2012/micro_perceptual_human_computation_for_visual_tasks.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_5_August_2012/micro_perceptual_human_computation_for_visual_tasks.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/GingoldSC12,
+  author    = {Yotam I. Gingold and
+               Ariel Shamir and
+               Daniel Cohen-Or},
+  title     = {Micro perceptual human computation for visual tasks},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {5},
+  year      = {2012},
+  pages     = {119},
+  ee        = {http://doi.acm.org/10.1145/2231816.2231817},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_5_August_2012/reflectance_model_for_diffraction.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_5_August_2012/reflectance_model_for_diffraction.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/CuypersHBOR12,
+  author    = {Tom Cuypers and
+               Tom Haber and
+               Philippe Bekaert and
+               Se Baek Oh and
+               Ramesh Raskar},
+  title     = {Reflectance model for diffraction},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {5},
+  year      = {2012},
+  pages     = {122},
+  ee        = {http://doi.acm.org/10.1145/2231816.2231820},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_5_August_2012/simple_formulas_for_quasiconformal_plane_deformations.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_5_August_2012/simple_formulas_for_quasiconformal_plane_deformations.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/LipmanKF12,
+  author    = {Yaron Lipman and
+               Vladimir G. Kim and
+               Thomas A. Funkhouser},
+  title     = {Simple formulas for quasiconformal plane deformations},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {5},
+  year      = {2012},
+  pages     = {124},
+  ee        = {http://doi.acm.org/10.1145/2231816.2231822},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_5_August_2012/theory,_analysis_and_applications_of_2d_global_illumination.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_5_August_2012/theory,_analysis_and_applications_of_2d_global_illumination.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/JaroszSKJ12,
+  author    = {Wojciech Jarosz and
+               Volker Sch{\"o}nefeld and
+               Leif Kobbelt and
+               Henrik Wann Jensen},
+  title     = {Theory, analysis and applications of 2D global illumination},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {5},
+  year      = {2012},
+  pages     = {125},
+  ee        = {http://doi.acm.org/10.1145/2231816.2231823},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_5_August_2012/updated_sparse_cholesky_factors_for_corotational_elastodynamics.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_5_August_2012/updated_sparse_cholesky_factors_for_corotational_elastodynamics.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/HechtLSO12,
+  author    = {Florian Hecht and
+               Yeon Jin Lee and
+               Jonathan Richard Shewchuk and
+               James F. O'Brien},
+  title     = {Updated sparse cholesky factors for corotational elastodynamics},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {5},
+  year      = {2012},
+  pages     = {123},
+  ee        = {http://doi.acm.org/10.1145/2231816.2231821},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_5_August_2012/video_stabilization_using_epipolar_geometry.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_5_August_2012/video_stabilization_using_epipolar_geometry.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/GoldsteinF12,
+  author    = {Amit Goldstein and
+               Raanan Fattal},
+  title     = {Video stabilization using epipolar geometry},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {5},
+  year      = {2012},
+  pages     = {126},
+  ee        = {http://doi.acm.org/10.1145/2231816.2231824},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/3d-printing_of_non-assembly,_articulated_models.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/3d-printing_of_non-assembly,_articulated_models.bib
@@ -1,0 +1,17 @@
+@article{DBLP:journals/tog/CaliCAKSKW12,
+  author    = {Jacques Cal\`{\i} and
+               Dan A. Calian and
+               Cristina Amati and
+               Rebecca Kleinberger and
+               Anthony Steed and
+               Jan Kautz and
+               Tim Weyrich},
+  title     = {3D-printing of non-assembly, articulated models},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {130},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366149},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/a_luminance-contrast-aware_disparity_model_and_applications.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/a_luminance-contrast-aware_disparity_model_and_applications.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/DidykREMSM12,
+  author    = {Piotr Didyk and
+               Tobias Ritschel and
+               Elmar Eisemann and
+               Karol Myszkowski and
+               Hans-Peter Seidel and
+               Wojciech Matusik},
+  title     = {A luminance-contrast-aware disparity model and applications},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {184},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366203},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/a_path_space_extension_for_robust_light_transport_simulation.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/a_path_space_extension_for_robust_light_transport_simulation.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/HachisukaPJ12,
+  author    = {Toshiya Hachisuka and
+               Jacopo Pantaleoni and
+               Henrik Wann Jensen},
+  title     = {A path space extension for robust light transport simulation},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {191},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366210},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/a_search-classify_approach_for_cluttered_indoor_scene_understanding.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/a_search-classify_approach_for_cluttered_indoor_scene_understanding.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/NanXS12,
+  author    = {Liangliang Nan and
+               Ke Xie and
+               Andrei Sharf},
+  title     = {A {\it search-classify} approach for cluttered indoor scene
+               understanding},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {137},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366156},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/a_statistical_similarity_measure_for_aggregate_crowd_dynamics.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/a_statistical_similarity_measure_for_aggregate_crowd_dynamics.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/GuyBLLLM12,
+  author    = {Stephen J. Guy and
+               Jur van den Berg and
+               Wenxi Liu and
+               Rynson W. H. Lau and
+               Ming C. Lin and
+               Dinesh Manocha},
+  title     = {A statistical similarity measure for aggregate crowd dynamics},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {190},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366209},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/a_vectorial_solver_for_free-form_vector_gradients.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/a_vectorial_solver_for_free-form_vector_gradients.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/BoyeBG12,
+  author    = {Simon Boy{\'e} and
+               Pascal Barla and
+               Ga{\"e}l Guennebaud},
+  title     = {A vectorial solver for free-form vector gradients},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {173},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366192},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/accurate_realtime_full-body_motion_capture_using_a_single_depth_camera.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/accurate_realtime_full-body_motion_capture_using_a_single_depth_camera.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/WeiZC12,
+  author    = {Xiaolin K. Wei and
+               Peizhao Zhang and
+               Jinxiang Chai},
+  title     = {Accurate realtime full-body motion capture using a single
+               depth camera},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {188},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366207},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/acquiring_3d_indoor_environments_with_variability_and_repetition.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/acquiring_3d_indoor_environments_with_variability_and_repetition.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/KimMYG12,
+  author    = {Young Min Kim and
+               Niloy J. Mitra and
+               Dong-Ming Yan and
+               Leonidas J. Guibas},
+  title     = {Acquiring 3D indoor environments with variability and repetition},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {138},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366157},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/active_co-analysis_of_a_set_of_shapes.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/active_co-analysis_of_a_set_of_shapes.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/WangAK0CC12,
+  author    = {Yunhai Wang and
+               Shmulik Asafi and
+               Oliver van Kaick and
+               Hao Zhang and
+               Daniel Cohen-Or and
+               Baoquan Chen},
+  title     = {Active co-analysis of a set of shapes},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {165},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366184},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/adaptive_anisotropic_remeshing_for_cloth_simulation.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/adaptive_anisotropic_remeshing_for_cloth_simulation.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/NarainSO12,
+  author    = {Rahul Narain and
+               Armin Samii and
+               James F. O'Brien},
+  title     = {Adaptive anisotropic remeshing for cloth simulation},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {152},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366171},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/adaptive_rendering_with_non-local_means_filtering.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/adaptive_rendering_with_non-local_means_filtering.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/RousselleKZ12,
+  author    = {Fabrice Rousselle and
+               Claude Knaus and
+               Matthias Zwicker},
+  title     = {Adaptive rendering with non-local means filtering},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {195},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366214},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/all-hex_meshing_using_singularity-restricted_field.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/all-hex_meshing_using_singularity-restricted_field.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/LiLXWG12,
+  author    = {Yufei Li and
+               Yang Liu and
+               Weiwei Xu and
+               Wenping Wang and
+               Baining Guo},
+  title     = {All-hex meshing using singularity-restricted field},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {177},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366196},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/an_interactive_approach_to_semantic_modeling_of_indoor_scenes_with_an_rgbd_camera.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/an_interactive_approach_to_semantic_modeling_of_indoor_scenes_with_an_rgbd_camera.bib
@@ -1,0 +1,17 @@
+@article{DBLP:journals/tog/ShaoXZWLG12,
+  author    = {Tianjia Shao and
+               Weiwei Xu and
+               Kun Zhou and
+               Jingdong Wang and
+               Dongping Li and
+               Baining Guo},
+  title     = {An interactive approach to semantic modeling of indoor scenes
+               with an RGBD camera},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {136},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366155},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/an_inverse_problem_approach_for_automatically_adjusting_the_parameters_for_rendering_clouds_using_photographs.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/an_inverse_problem_approach_for_automatically_adjusting_the_parameters_for_rendering_clouds_using_photographs.bib
@@ -1,0 +1,17 @@
+@article{DBLP:journals/tog/DobashiIOYYN12,
+  author    = {Yoshinori Dobashi and
+               Wataru Iwasaki and
+               Ayumi Ono and
+               Tsuyoshi Yamamoto and
+               Yonghao Yue and
+               Tomoyuki Nishita},
+  title     = {An inverse problem approach for automatically adjusting
+               the parameters for rendering clouds using photographs},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {145},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366164},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/an_optimization_approach_for_extracting_and_encoding_consistent_maps_in_a_shape_collection.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/an_optimization_approach_for_extracting_and_encoding_consistent_maps_in_a_shape_collection.bib
@@ -1,0 +1,17 @@
+@article{DBLP:journals/tog/HuangZGHBG12,
+  author    = {Qi-Xing Huang and
+               Guo-Xin Zhang and
+               Lin Gao and
+               Shi-Min Hu and
+               Adrian Butscher and
+               Leonidas J. Guibas},
+  title     = {An optimization approach for extracting and encoding consistent
+               maps in a shape collection},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {167},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366186},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/analysis_and_synthesis_of_point_distributions_based_on_pair_correlation.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/analysis_and_synthesis_of_point_distributions_based_on_pair_correlation.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/OztireliG12,
+  author    = {A. Cengiz {\"O}ztireli and
+               Markus H. Gross},
+  title     = {Analysis and synthesis of point distributions based on pair
+               correlation},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {170},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366189},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/automated_constraint_placement_to_maintain_pile_shape.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/automated_constraint_placement_to_maintain_pile_shape.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/HsuK12,
+  author    = {Shu-Wei Hsu and
+               John Keyser},
+  title     = {Automated constraint placement to maintain pile shape},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {150},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366169},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/automatic_stylistic_manga_layout.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/automatic_stylistic_manga_layout.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/CaoCL12,
+  author    = {Ying Cao and
+               Antoni B. Chan and
+               Rynson W. H. Lau},
+  title     = {Automatic stylistic manga layout},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {141},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366160},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/axis-aligned_filtering_for_interactive_sampled_soft_shadows.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/axis-aligned_filtering_for_interactive_sampled_soft_shadows.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/MehtaWR12,
+  author    = {Soham Uday Mehta and
+               Brandon Wang and
+               Ravi Ramamoorthi},
+  title     = {Axis-aligned filtering for interactive sampled soft shadows},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {163},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366182},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/blue_noise_through_optimal_transport.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/blue_noise_through_optimal_transport.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/GoesBOD12,
+  author    = {Fernando de Goes and
+               Katherine Breeden and
+               Victor Ostromoukhov and
+               Mathieu Desbrun},
+  title     = {Blue noise through optimal transport},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {171},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366190},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/calibrated_image_appearance_reproduction.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/calibrated_image_appearance_reproduction.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/ReinhardPKLBD12,
+  author    = {Erik Reinhard and
+               Tania Pouli and
+               Timo Kunkel and
+               Benjamin Long and
+               Anders Ballestad and
+               Gerwin Damberg},
+  title     = {Calibrated image appearance reproduction},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {201},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366220},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/capturing_and_animating_the_morphogenesis_of_polygonal_tree_models.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/capturing_and_animating_the_morphogenesis_of_polygonal_tree_models.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/PirkNDN12,
+  author    = {S{\"o}ren Pirk and
+               Till Niese and
+               Oliver Deussen and
+               Boris Neubert},
+  title     = {Capturing and animating the morphogenesis of polygonal tree
+               models},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {169},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366188},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/chopper_partitioning_models_into_3d-printable_parts.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/chopper_partitioning_models_into_3d-printable_parts.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/LuoBRM12,
+  author    = {Linjie Luo and
+               Ilya Baran and
+               Szymon Rusinkiewicz and
+               Wojciech Matusik},
+  title     = {Chopper: partitioning models into 3D-printable parts},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {129},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366148},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/co-abstraction_of_shape_collections.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/co-abstraction_of_shape_collections.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/YumerK12,
+  author    = {Mehmet Ersin Y{\"u}mer and
+               Levent Burak Kara},
+  title     = {Co-abstraction of shape collections},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {166},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366185},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/coherent_intrinsic_images_from_photo_collections.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/coherent_intrinsic_images_from_photo_collections.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/LaffontBPDD12,
+  author    = {Pierre-Yves Laffont and
+               Adrien Bousseau and
+               Sylvain Paris and
+               Fr{\'e}do Durand and
+               George Drettakis},
+  title     = {Coherent intrinsic images from photo collections},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {202},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366221},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/correcting_for_optical_aberrations_using_multilayer_displays.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/correcting_for_optical_aberrations_using_multilayer_displays.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/HuangLBR12,
+  author    = {Fu-Chung Huang and
+               Douglas Lanman and
+               Brian A. Barsky and
+               Ramesh Raskar},
+  title     = {Correcting for optical aberrations using multilayer displays},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {185},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366204},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/data-driven_finger_motion_synthesis_for_gesturing_characters.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/data-driven_finger_motion_synthesis_for_gesturing_characters.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/JorgHS12,
+  author    = {Sophie J{\"o}rg and
+               Jessica K. Hodgins and
+               Alla Safonova},
+  title     = {Data-driven finger motion synthesis for gesturing characters},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {189},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366208},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/depth-presorted_triangle_lists.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/depth-presorted_triangle_lists.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/ChenSNYH12,
+  author    = {Ge Chen and
+               Pedro V. Sander and
+               Diego Nehab and
+               Lei Yang and
+               Liang Hu},
+  title     = {Depth-presorted triangle lists},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {160},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366179},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/design-driven_quadrangulation_of_closed_3d_curves.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/design-driven_quadrangulation_of_closed_3d_curves.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/BessmeltsevWSS12,
+  author    = {Mikhail Bessmeltsev and
+               Caoyu Wang and
+               Alla Sheffer and
+               Karan Singh},
+  title     = {Design-driven quadrangulation of closed 3D curves},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {178},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366197},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/digital_reconstruction_of_halftoned_color_comics.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/digital_reconstruction_of_halftoned_color_comics.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/KopfL12,
+  author    = {Johannes Kopf and
+               Dani Lischinski},
+  title     = {Digital reconstruction of halftoned color comics},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {140},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366159},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/discontinuity-aware_video_object_cutout.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/discontinuity-aware_video_object_cutout.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/ZhongQPM12,
+  author    = {Fan Zhong and
+               Xueying Qin and
+               Qunsheng Peng and
+               Xiangxu Meng},
+  title     = {Discontinuity-aware video object cutout},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {175},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366194},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/dressup!_outfit_synthesis_through_automatic_optimization.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/dressup!_outfit_synthesis_through_automatic_optimization.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/YuYTC12,
+  author    = {Lap-Fai Yu and
+               Sai Kit Yeung and
+               Demetri Terzopoulos and
+               Tony F. Chan},
+  title     = {DressUp!: outfit synthesis through automatic optimization},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {134},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366153},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/elasticity-inspired_deformers_for_character_articulation.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/elasticity-inspired_deformers_for_character_articulation.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/KavanS12,
+  author    = {Ladislav Kavan and
+               Olga Sorkine},
+  title     = {Elasticity-inspired deformers for character articulation},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {196},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366215},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/enabling_warping_on_stereoscopic_images.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/enabling_warping_on_stereoscopic_images.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/NiuFL12,
+  author    = {Yuzhen Niu and
+               Wu-chi Feng and
+               Feng Liu},
+  title     = {Enabling warping on stereoscopic images},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {183},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366202},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/example-based_synthesis_of_3d_object_arrangements.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/example-based_synthesis_of_3d_object_arrangements.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/FisherRSFH12,
+  author    = {Matthew Fisher and
+               Daniel Ritchie and
+               Manolis Savva and
+               Thomas A. Funkhouser and
+               Pat Hanrahan},
+  title     = {Example-based synthesis of 3D object arrangements},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {135},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366154},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/falling_and_landing_motion_control_for_character_animation.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/falling_and_landing_motion_control_for_character_animation.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/HaYL12,
+  author    = {Sehoon Ha and
+               Yuting Ye and
+               C. Karen Liu},
+  title     = {Falling and landing motion control for character animation},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {155},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366174},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/field-guided_registration_for_feature-conforming_shape_composition.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/field-guided_registration_for_feature-conforming_shape_composition.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/0004GCOT012,
+  author    = {Hui Huang and
+               Minglun Gong and
+               Daniel Cohen-Or and
+               Yaobin Ouyang and
+               Fuwen Tan and
+               Hao Zhang},
+  title     = {Field-guided registration for feature-conforming shape composition},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {179},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366198},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/foveated_3d_graphics.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/foveated_3d_graphics.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/GuenterFDTS12,
+  author    = {Brian Guenter and
+               Mark Finch and
+               Steven Drucker and
+               Desney Tan and
+               John Snyder},
+  title     = {Foveated 3D graphics},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {164},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366183},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/gaze_correction_for_home_video_conferencing.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/gaze_correction_for_home_video_conferencing.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/KusterPBGG12,
+  author    = {Claudia Kuster and
+               Tiberiu Popa and
+               Jean Charles Bazin and
+               Craig Gotsman and
+               Markus H. Gross},
+  title     = {Gaze correction for home video conferencing},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {174},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366193},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/gpu-accelerated_path_rendering.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/gpu-accelerated_path_rendering.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/KilgardB12,
+  author    = {Mark J. Kilgard and
+               Jeff Bolz},
+  title     = {GPU-accelerated path rendering},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {172},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366191},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/high-quality_curve_rendering_using_line_sampled_visibility.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/high-quality_curve_rendering_using_line_sampled_visibility.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/BarringerGA12,
+  author    = {Rasmus Barringer and
+               Carl Johan Gribel and
+               Tomas Akenine-M{\"o}ller},
+  title     = {High-quality curve rendering using line sampled visibility},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {162},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366181},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/interactive_bi-scale_editing_of_highly_glossy_materials.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/interactive_bi-scale_editing_of_highly_glossy_materials.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/IwasakiDN12,
+  author    = {Kei Iwasaki and
+               Yoshinori Dobashi and
+               Tomoyuki Nishita},
+  title     = {Interactive bi-scale editing of highly glossy materials},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {144},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366163},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/inverse_design_of_urban_procedural_models.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/inverse_design_of_urban_procedural_models.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/VanegasGABW12,
+  author    = {Carlos A. Vanegas and
+               Ignacio Garcia-Dorado and
+               Daniel G. Aliaga and
+               Bedrich Benes and
+               Paul Waddell},
+  title     = {Inverse design of urban procedural models},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {168},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366187},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/large-scale_fluid_simulation_using_velocity-vorticity_domain_decomposition.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/large-scale_fluid_simulation_using_velocity-vorticity_domain_decomposition.bib
@@ -1,0 +1,17 @@
+@article{DBLP:journals/tog/GolasNSKDL12,
+  author    = {Abhinav Golas and
+               Rahul Narain and
+               Jason Sewall and
+               Pavel Krajcevski and
+               Pradeep Dubey and
+               Ming C. Lin},
+  title     = {Large-scale fluid simulation using velocity-vorticity domain
+               decomposition},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {148},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366167},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/lazy_selection_a_scribble-based_tool_for_smart_shape_elements_selection.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/lazy_selection_a_scribble-based_tool_for_smart_shape_elements_selection.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/XuFAT12,
+  author    = {Pengfei Xu and
+               Hongbo Fu and
+               Oscar Kin-Chung Au and
+               Chiew-Lan Tai},
+  title     = {Lazy selection: a scribble-based tool for smart shape elements
+               selection},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {142},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366161},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/light_transport_simulation_with_vertex_connection_and_merging.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/light_transport_simulation_with_vertex_connection_and_merging.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/GeorgievKDS12,
+  author    = {Iliyan Georgiev and
+               Jaroslav Kriv{\'a}nek and
+               Tom{\'a}s Davidovic and
+               Philipp Slusallek},
+  title     = {Light transport simulation with vertex connection and merging},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {192},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366211},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/lighting_hair_from_the_inside_a_thermal_approach_to_hair_reconstruction.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/lighting_hair_from_the_inside_a_thermal_approach_to_hair_reconstruction.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/HerreraZ012,
+  author    = {Tom{\'a}s Lay Herrera and
+               Arno Zinke and
+               Andreas Weber},
+  title     = {Lighting hair from the inside: a thermal approach to hair
+               reconstruction},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {146},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366165},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/lightweight_binocular_facial_performance_capture_under_uncontrolled_lighting.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/lightweight_binocular_facial_performance_capture_under_uncontrolled_lighting.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/ValgaertsWBST12,
+  author    = {Levi Valgaerts and
+               Chenglei Wu and
+               Andr{\'e}s Bruhn and
+               Hans-Peter Seidel and
+               Christian Theobalt},
+  title     = {Lightweight binocular facial performance capture under uncontrolled
+               lighting},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {187},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366206},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/manifold_preserving_edit_propagation.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/manifold_preserving_edit_propagation.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/ChenZZT12,
+  author    = {Xiaowu Chen and
+               Dongqing Zou and
+               Qinping Zhao and
+               Ping Tan},
+  title     = {Manifold preserving edit propagation},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {132},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366151},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/material_memex_automatic_material_suggestions_for_3d_objects.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/material_memex_automatic_material_suggestions_for_3d_objects.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/JainTRS12,
+  author    = {Arjun Jain and
+               Thorsten Thorm{\"a}hlen and
+               Tobias Ritschel and
+               Hans-Peter Seidel},
+  title     = {Material memex: automatic material suggestions for 3D objects},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {143},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366162},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/motion-guided_mechanical_toy_modeling.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/motion-guided_mechanical_toy_modeling.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/ZhuXSLWG12,
+  author    = {Lifeng Zhu and
+               Weiwei Xu and
+               John Snyder and
+               Yang Liu and
+               Guoping Wang and
+               Baining Guo},
+  title     = {Motion-guided mechanical toy modeling},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {127},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366146},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/motion_graphs++_a_compact_generative_model_for_semantic_motion_analysis_and_synthesis.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/motion_graphs++_a_compact_generative_model_for_semantic_motion_analysis_and_synthesis.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/MinC12,
+  author    = {Jianyuan Min and
+               Jinxiang Chai},
+  title     = {Motion graphs++: a compact generative model for semantic
+               motion analysis and synthesis},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {153},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366172},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/multi-scale_partial_intrinsic_symmetry_detection.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/multi-scale_partial_intrinsic_symmetry_detection.bib
@@ -1,0 +1,17 @@
+@article{DBLP:journals/tog/00040JDCLC12,
+  author    = {Kai Xu and
+               Hao Zhang and
+               Wei Jiang and
+               Ramsay Dyer and
+               Zhi-Quan Cheng and
+               Ligang Liu and
+               Baoquan Chen},
+  title     = {Multi-scale partial intrinsic symmetry detection},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {181},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366200},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/new_measurements_reveal_weaknesses_of_image_quality_metrics_in_evaluating_graphics_artifacts.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/new_measurements_reveal_weaknesses_of_image_quality_metrics_in_evaluating_graphics_artifacts.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/CadikHMMS12,
+  author    = {Martin Cad\'{\i}k and
+               Robert Herzog and
+               Rafal Mantiuk and
+               Karol Myszkowski and
+               Hans-Peter Seidel},
+  title     = {New measurements reveal weaknesses of image quality metrics
+               in evaluating graphics artifacts},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {147},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366166},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/perspective-aware_warping_for_seamless_stereoscopic_image_cloning.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/perspective-aware_warping_for_seamless_stereoscopic_image_cloning.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/LuoSCCC12,
+  author    = {Sheng-Jie Luo and
+               I-Chao Shen and
+               Bing-Yu Chen and
+               Wen-Huang Cheng and
+               Yung-Yu Chuang},
+  title     = {Perspective-aware warping for seamless stereoscopic image
+               cloning},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {182},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366201},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/practical_hessian-based_error_control_for_irradiance_caching.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/practical_hessian-based_error_control_for_irradiance_caching.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/SchwarzhauptJJ12,
+  author    = {Jorge Schwarzhaupt and
+               Henrik Wann Jensen and
+               Wojciech Jarosz},
+  title     = {Practical Hessian-based error control for irradiance caching},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {193},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366212},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/quality_prediction_for_image_completion.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/quality_prediction_for_image_completion.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/KopfKDK12,
+  author    = {Johannes Kopf and
+               Wolf Kienzle and
+               Steven M. Drucker and
+               Sing Bing Kang},
+  title     = {Quality prediction for image completion},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {131},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366150},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/recursive_interlocking_puzzles.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/recursive_interlocking_puzzles.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/SongFC12,
+  author    = {Peng Song and
+               Chi-Wing Fu and
+               Daniel Cohen-Or},
+  title     = {Recursive interlocking puzzles},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {128},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366147},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/rigmesh_automatic_rigging_for_part-based_shape_modeling_and_deformation.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/rigmesh_automatic_rigging_for_part-based_shape_modeling_and_deformation.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/BorosanJDGN12,
+  author    = {P{\'e}ter Boros{\'a}n and
+               Ming Jin and
+               Doug DeCarlo and
+               Yotam I. Gingold and
+               Andrew Nealen},
+  title     = {RigMesh: automatic rigging for part-based shape modeling
+               and deformation},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {198},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366217},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/robust_patch-based_hdr_reconstruction_of_dynamic_scenes.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/robust_patch-based_hdr_reconstruction_of_dynamic_scenes.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/SenKYDGS12,
+  author    = {Pradeep Sen and
+               Nima Khademi Kalantari and
+               Maziar Yaesoubi and
+               Soheil Darabi and
+               Dan B. Goldman and
+               Eli Shechtman},
+  title     = {Robust patch-based hdr reconstruction of dynamic scenes},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {203},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366222},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/sculpting_by_numbers.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/sculpting_by_numbers.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/RiversAD12,
+  author    = {Alec R. Rivers and
+               Andrew Adams and
+               Fr{\'e}do Durand},
+  title     = {Sculpting by numbers},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {157},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366176},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/simulation_of_complex_nonlinear_elastic_bodies_using_lattice_deformers.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/simulation_of_complex_nonlinear_elastic_bodies_using_lattice_deformers.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/PattersonMS12,
+  author    = {Taylor Patterson and
+               Nathan Mitchell and
+               Eftychios Sifakis},
+  title     = {Simulation of complex nonlinear elastic bodies using lattice
+               deformers},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {197},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366216},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/smooth_skinning_decomposition_with_rigid_bones.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/smooth_skinning_decomposition_with_rigid_bones.bib
@@ -1,0 +1,12 @@
+@article{DBLP:journals/tog/LeD12,
+  author    = {Binh Huy Le and
+               Zhigang Deng},
+  title     = {Smooth skinning decomposition with rigid bones},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {199},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366218},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/softshell_dynamic_scheduling_on_gpus.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/softshell_dynamic_scheduling_on_gpus.bib
@@ -1,0 +1,16 @@
+@article{DBLP:journals/tog/SteinbergerKKHKS12,
+  author    = {Markus Steinberger and
+               Bernhard Kainz and
+               Bernhard Kerbl and
+               Stefan Hauswiesner and
+               Michael Kenzel and
+               Dieter Schmalstieg},
+  title     = {Softshell: dynamic scheduling on GPUs},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {161},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366180},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/sparse_pdf_maps_for_non-linear_multi-resolution_image_operations.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/sparse_pdf_maps_for_non-linear_multi-resolution_image_operations.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/HadwigerSBKM12,
+  author    = {Markus Hadwiger and
+               Ronell Sicat and
+               Johanna Beyer and
+               Jens Kr{\"u}ger and
+               Torsten M{\"o}ller},
+  title     = {Sparse PDF maps for non-linear multi-resolution image operations},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {133},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366152},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/speculative_parallel_asynchronous_contact_mechanics.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/speculative_parallel_asynchronous_contact_mechanics.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/AinsleyVGT12,
+  author    = {Samantha Ainsley and
+               Etienne Vouga and
+               Eitan Grinspun and
+               Rasmus Tamstorf},
+  title     = {Speculative parallel asynchronous contact mechanics},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {151},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366170},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/stackabilization.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/stackabilization.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/LiA0SC12,
+  author    = {Honghua Li and
+               Ibraheem Alhashim and
+               Hao Zhang and
+               Ariel Shamir and
+               Daniel Cohen-Or},
+  title     = {Stackabilization},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {158},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366177},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/staggered_meshless_solid-fluid_coupling.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/staggered_meshless_solid-fluid_coupling.bib
@@ -1,0 +1,17 @@
+@article{DBLP:journals/tog/HeLWZLSW12,
+  author    = {Xiaowei He and
+               Ning Liu and
+               Guoping Wang and
+               Fengjun Zhang and
+               Sheng Li and
+               Songdong Shao and
+               Hongan Wang},
+  title     = {Staggered meshless solid-fluid coupling},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {149},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366168},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/structural_optimization_of_3d_masonry_buildings.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/structural_optimization_of_3d_masonry_buildings.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/WhitingSWOD12,
+  author    = {Emily Whiting and
+               Hijung Shin and
+               Robert Wang and
+               John Ochsendorf and
+               Fr{\'e}do Durand},
+  title     = {Structural optimization of 3D masonry buildings},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {159},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366178},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/structure_extraction_from_texture_via_relative_total_variation.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/structure_extraction_from_texture_via_relative_total_variation.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/XuYXJ12,
+  author    = {Li Xu and
+               Qiong Yan and
+               Yang Xia and
+               Jiaya Jia},
+  title     = {Structure extraction from texture via relative total variation},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {139},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366158},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/structure_recovery_by_part_assembly.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/structure_recovery_by_part_assembly.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/ShenFCH12,
+  author    = {Chao-Hui Shen and
+               Hongbo Fu and
+               Kang Chen and
+               Shi-Min Hu},
+  title     = {Structure recovery by part assembly},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {180},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366199},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/sure-based_optimization_for_adaptive_sampling_and_reconstruction.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/sure-based_optimization_for_adaptive_sampling_and_reconstruction.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/LiWC12,
+  author    = {Tzu-Mao Li and
+               Yu-Ting Wu and
+               Yung-Yu Chuang},
+  title     = {SURE-based optimization for adaptive sampling and reconstruction},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {194},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366213},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/synthesis_of_concurrent_object_manipulation_tasks.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/synthesis_of_concurrent_object_manipulation_tasks.bib
@@ -1,0 +1,13 @@
+@article{DBLP:journals/tog/BaiSL12,
+  author    = {Yunfei Bai and
+               Kristin Siu and
+               C. Karen Liu},
+  title     = {Synthesis of concurrent object manipulation tasks},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {156},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366175},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/terrain_runner_control,_parameterization,_composition,_and_planning_for_highly_dynamic_motions.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/terrain_runner_control,_parameterization,_composition,_and_planning_for_highly_dynamic_motions.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/LiuYPG12,
+  author    = {Libin Liu and
+               KangKang Yin and
+               Michiel van de Panne and
+               Baining Guo},
+  title     = {Terrain runner: control, parameterization, composition,
+               and planning for highly dynamic motions},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {154},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366173},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/the_magic_lens_refractive_steganography.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/the_magic_lens_refractive_steganography.bib
@@ -1,0 +1,15 @@
+@article{DBLP:journals/tog/PapasHNGJ12,
+  author    = {Marios Papas and
+               Thomas Houit and
+               Derek Nowrouzezahrai and
+               Markus H. Gross and
+               Wojciech Jarosz},
+  title     = {The magic lens: refractive steganography},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {186},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366205},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/transfusive_image_manipulation.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/transfusive_image_manipulation.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/YucerJHS12,
+  author    = {Kaan Y{\"u}cer and
+               Alec Jacobson and
+               Alexander Hornung and
+               Olga Sorkine},
+  title     = {Transfusive image manipulation},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {176},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366195},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/user-guided_white_balance_for_mixed_lighting_conditions.bib
+++ b/dblp_bibtex_fetcher/Volume_31_Number_6_November_2012/user-guided_white_balance_for_mixed_lighting_conditions.bib
@@ -1,0 +1,14 @@
+@article{DBLP:journals/tog/BoyadzhievBPD12,
+  author    = {Ivaylo Boyadzhiev and
+               Kavita Bala and
+               Sylvain Paris and
+               Fr{\'e}do Durand},
+  title     = {User-guided white balance for mixed lighting conditions},
+  journal   = {ACM Trans. Graph.},
+  volume    = {31},
+  number    = {6},
+  year      = {2012},
+  pages     = {200},
+  ee        = {http://doi.acm.org/10.1145/2366145.2366219},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}

--- a/dblp_bibtex_fetcher/dblp_bibtex_fetcher.py
+++ b/dblp_bibtex_fetcher/dblp_bibtex_fetcher.py
@@ -1,0 +1,117 @@
+# file: dblp_bibtex_fetcher.py
+# date: 08/24/2013
+# author: Tzu-Mao Li
+# description: a parser to obtain the bibtex files from a dblp webpage
+#              input the url(e.g. http://www.informatik.uni-trier.de/~ley/db/journals/tog/tog31.html )
+#              and the program will automatically create folders and files under the current directory
+
+import urllib2
+import sys
+import os
+from HTMLParser import HTMLParser
+
+bibtexBaseUrl = 'http://dblp.uni-trier.de/rec/bibtex/'
+
+class DBLPBibtexParser(HTMLParser):
+    def __init__(self):
+        HTMLParser.__init__(self)
+        self.bibModeFlag = False
+        self.bibtexContent = ''
+    def handle_starttag(self, tag, attrs):
+        if(tag == 'pre'):
+            self.bibModeFlag = True
+    def handle_endtag(self, tag):
+        if(tag == 'pre'):
+            self.bibModeFlag = False            
+    def handle_data(self, data):
+        if(self.bibModeFlag):
+            self.bibtexContent = self.bibtexContent + data
+
+class DBLPWebpageParser(HTMLParser):    
+    def __init__(self):
+        HTMLParser.__init__(self)
+        self.headerModeFlag = False
+        self.issueModeFlag = False
+        self.titleModeFlag = False
+        self.currentTitle = ''
+    def handle_starttag(self, tag, attrs):        
+        if(tag == 'header'):
+            self.headerModeFlag = True
+        elif(tag == 'h2'):
+            self.issueModeFlag = True
+        elif(tag == 'li'):
+            dictAttr = dict(attrs)
+            try:                
+                if(dictAttr['class'] == 'entry article'):
+                    articleId = dictAttr['id']
+                    self.articleId = articleId
+                    self.bibtexUrl = bibtexBaseUrl + articleId                    
+            except KeyError:
+                pass
+        elif(tag == 'span'):
+            dictAttr = dict(attrs)
+            try:                
+                if(dictAttr['class'] == 'title'):
+                    self.titleModeFlag = True                 
+            except KeyError:
+                pass            
+            
+    def handle_endtag(self, tag):
+        if(tag == 'header'):
+            self.headerModeFlag = False
+        elif(tag == 'h2'):
+            self.issueModeFlag = False
+        elif(tag == 'span'):
+            if(self.titleModeFlag):
+                self.titleModeFlag = False            
+                # do some string processing to conver title to file name                
+                title = self.currentTitle[0:len(self.currentTitle)-1] # remove period
+                title = title.replace(' ', '_') # replace space by underline
+                # remove special characters
+                title = title.replace('\\', '')
+                title = title.replace('/', '')            
+                title = title.replace(':', '')
+                title = title.replace('*', '')
+                title = title.replace('?', '')
+                title = title.replace('\"', '')
+                title = title.replace('<', '')
+                title = title.replace('>', '')
+                title = title.replace('|', '')
+                title = title.lower()
+                print 'articleId:' + self.articleId
+                print 'title:' + title
+                self.currentTitle = ''
+
+                # write bibtex to file
+                f = open(self.currentPath + title + '.bib', 'w')
+                response = urllib2.urlopen(self.bibtexUrl)
+                content = response.read()
+                parser = DBLPBibtexParser()
+                parser.feed(content)
+                f.write(parser.bibtexContent)
+                f.close()
+    def handle_data(self, data):
+        if(self.issueModeFlag):
+            dirName = data.replace(',', '').replace(' ', '_')
+            if not os.path.isdir(dirName):
+                os.mkdir(dirName)
+            self.currentPath = dirName + os.path.sep
+        elif(self.titleModeFlag):
+            self.currentTitle = self.currentTitle + data
+
+
+def main():
+    if len(sys.argv) < 2:
+        print 'Usage: python dblp_bibtex_fetcher.py [url]'
+        sys.exit()
+
+    for i in xrange(1, len(sys.argv)):        
+        url = sys.argv[i]
+        
+        response = urllib2.urlopen(url)
+        content = response.read()
+        parser = DBLPWebpageParser()
+        parser.feed(content)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
dblp_bibtex_fetcher/dblp_bibtex_fetcher.py automatically grab bibtex files from the dblp website.
For example, http://www.informatik.uni-trier.de/~ley/db/journals/tog/tog31.html contains the list of TOG papers published in 2012, including SIGGRAPH 2012(issue no. 4) and SIGGRAPH Asia 2012(issue no. 6) papers. Executing "python dblp_bibtex_fetcher.py http://www.informatik.uni-trier.de/~ley/db/journals/tog/tog31.html" will create a directory for each issue and put the bibtex files in the directory.

I will commit more bibtex of recent SIGGRAPH papers later :p
